### PR TITLE
Add signals for a game to unload and reload itself

### DIFF
--- a/Game.gd
+++ b/Game.gd
@@ -4,16 +4,31 @@ class_name Game
 var has_won:bool = false
 var high_score:int = 0
 
+## Tells the game system to exit to the menu
+signal quit_game()
+
+## Tells the game system to reload the current game
+signal restart_game()
+
+## Tells the game system to persist the given save_data to disk
+## Note that this overwrites any previous save data for the current instance
+## Will be loaded on next game start by calling load_save_data
+# TODO [#5] Call load_save_data
+signal save_game(save_data:Dictionary)
+
+## Instance data used for the game selection menu
 var game_instance_data:GameInstanceData
 
-func game_init():
+## Called after the game has all values set by GameLoader,
+##  but before the Game is added to the scene tree.
+## If the game must be in the scene tree, use _ready instead
+func _on_game_initialized():
 	seed(game_instance_data.random_seed)
 
-func game_start():
+## Called when the game is paused
+func _on_game_paused():
 	pass
 
-func game_pause():
-	pass
-
-func game_exit():
+## Called when the game is quit, just before being freed
+func _on_game_quit():
 	pass

--- a/GameLoader.gd
+++ b/GameLoader.gd
@@ -2,20 +2,27 @@ extends Node2D
 class_name GameLoader
 
 var current_game:Game = null
-signal start_menu_music
 
 func unload_current_game():
 	if current_game != null:
-		current_game.game_exit()
+		current_game._on_game_quit()
 		current_game.queue_free()
 		current_game = null
-		emit_signal("start_menu_music")
 
 func load_game(game_instance_data):
 	unload_current_game()
 	
 	current_game = game_instance_data.game_scene.instantiate()
 	current_game.game_instance_data = game_instance_data
-	current_game.game_init()
+	current_game.quit_game.connect($"../PauseMenu".quit_game)
+	current_game.restart_game.connect(reload_current_game)
+	# TODO [#5]: Add save_game method to connect here
+	#current_game.save_game.connect(%Main.save_gave)
+	current_game._on_game_initialized()
 	add_child(current_game)
-	current_game.game_start()
+
+func reload_current_game():
+	if current_game != null:
+		var current_instance_data := current_game.game_instance_data
+		unload_current_game()
+		load_game(current_instance_data)

--- a/GameSelect.gd
+++ b/GameSelect.gd
@@ -65,18 +65,15 @@ func sync_game_info():
 func play_current_selection():
 	game_loader.load_game(current_game_data)
 	close_menu()
-	menu_music.stop()
 
 func close_menu():
 	hide()
+	menu_music.stop()
 	$"../ScrollingBackground".hide()
 	process_mode = Node.PROCESS_MODE_DISABLED
 
 func open_menu():
 	show()
+	menu_music.play()
 	$"../ScrollingBackground".show()
 	process_mode = Node.PROCESS_MODE_INHERIT
-
-
-func _on_game_loader_start_menu_music():
-	menu_music.play()

--- a/PauseMenu.gd
+++ b/PauseMenu.gd
@@ -11,6 +11,7 @@ func toggle_pause():
 		get_tree().paused = true
 		$ResumeButton.grab_focus()
 		show()
+		game_loader.current_game._on_game_paused()
 	else:
 		get_tree().paused = false
 		hide()

--- a/games/ShootEmUp/scripts/ShootEmUp.gd
+++ b/games/ShootEmUp/scripts/ShootEmUp.gd
@@ -29,14 +29,11 @@ func _on_enemy_died(score_to_add):
 func _process(delta):
 	pass
 
-func game_init():
-	super.game_init()
+func _on_game_initialized():
+	super._on_game_initialized()
 
-func game_start():
-	super.game_start()
+func _on_game_paused():
+	super._on_game_paused()
 
-func game_pause():
-	super.game_pause()
-
-func game_exit():
-	super.game_exit()
+func _on_game_quit():
+	super._on_game_quit()

--- a/main.tscn
+++ b/main.tscn
@@ -152,6 +152,19 @@ theme_override_font_sizes/font_size = 60
 text = "Exit Game
 "
 
+[node name="RestartButton" type="Button" parent="PauseMenu"]
+offset_left = 602.0
+offset_top = 651.0
+offset_right = 1036.0
+offset_bottom = 753.0
+focus_neighbor_top = NodePath("../ResumeButton")
+focus_next = NodePath("../ResumeButton")
+focus_previous = NodePath("../ResumeButton")
+theme_override_fonts/font = ExtResource("10_xafrm")
+theme_override_font_sizes/font_size = 60
+text = "Restart
+"
+
 [node name="MenuMusic" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("41_68xfp")
 
@@ -165,6 +178,7 @@ stream = ExtResource("42_xy017")
 [connection signal="pressed" from="GameSelect/UpButton" to="GameSelect" method="_on_button_up_pressed"]
 [connection signal="pressed" from="GameSelect/DownButton" to="GameSelect" method="_on_button_down_pressed"]
 [connection signal="pressed" from="GameSelect/GameSelectWindow" to="GameSelect" method="_on_button_select_pressed"]
-[connection signal="start_menu_music" from="GameLoader" to="GameSelect" method="_on_game_loader_start_menu_music"]
 [connection signal="pressed" from="PauseMenu/ResumeButton" to="PauseMenu" method="toggle_pause"]
 [connection signal="pressed" from="PauseMenu/ExitButton" to="PauseMenu" method="quit_game"]
+[connection signal="pressed" from="PauseMenu/RestartButton" to="GameLoader" method="reload_current_game" flags=3]
+[connection signal="pressed" from="PauseMenu/RestartButton" to="PauseMenu" method="toggle_pause"]


### PR DESCRIPTION
Add `quit_game` signal to `Game` for quitting the current game

Add `restart_game` signal to `Game` for restarting the current game

Add `save_game` signal to `Game` to later be used for saving the game (in #5)

Update the `Game` overridable methods to have more accurate names & descriptions

Move menu music play/stop to be totally in the `GameSelect.gd` for proper encapsulation

Fix issue with main menu not allowing clicking the game images

Closes #17 Add ability to base game class to unload itself